### PR TITLE
Add 'gulp-gh-pages' module to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "gulp-assetpaths": "^0.1.1",
     "gulp-declare": "^0.3.0",
     "gulp-define-module": "^0.1.1",
+    "gulp-gh-pages": "^0.5.0",
     "gulp-handlebars": "^3.0.1",
     "gulp-ruby-sass": "^1.0.0-alpha",
     "run-sequence": "^1.0.2"


### PR DESCRIPTION
Hi,

When trying to run `gulp` it throws the 'Cannot find module' error. Checking the dev dependencies section in package.json file, the mentioned module wasn't there.
